### PR TITLE
Add AGENTS-QC-010 and AGENTS-QC-011 size/bloat checks

### DIFF
--- a/make_AGENTS.md
+++ b/make_AGENTS.md
@@ -112,8 +112,8 @@ For detailed structure, see `make_AGENTS.json`.
 
 ### 2. Concise — Project Context, Not Documentation
 **Description**: AGENTS.md is the file the LLM reads first when working in a project. It is project context, not exhaustive documentation. Long AGENTS.md files dilute their own purpose.
-**Why**: An LLM that has to read 2000 lines of project context before answering a simple question burns budget and surfaces noise. The first 100 lines do 80% of the work.
-**How**: Required sections aim for ~30 lines each. Optional sections only when they earn their presence. Long-form documentation lives in READMEs, not AGENTS.md.
+**Why**: An LLM that has to read 2000 lines of project context before answering a simple question burns budget and surfaces noise. The first 100 lines do 80% of the work. Beyond ~25,000 tokens, the file exceeds common Read-tool limits and becomes unreadable in one pass.
+**How**: Required sections aim for ~30 lines each. Optional sections only when they earn their presence. Long-form documentation lives in READMEs, not AGENTS.md. **Enforced by**: AGENTS-QC-010 (total file size thresholds: soft warn at 1200 lines/12k tokens, hard flag at 25k tokens) and AGENTS-QC-011 (Active Context current-state-only check: flags when >5 dated entries or >150 lines).
 
 ### 3. Active-State-Aware
 **Description**: Every AGENTS.md has an "Active Context" section that surfaces in-flight work, recent major changes, and known follow-ups. This is the section that decays fastest and matters most.
@@ -209,13 +209,13 @@ All three kill the propagation — (a) by duplication-drift, (b) by broken-refer
 - **During refresh, SCAN for stale vendoring-pattern language and REWRITE** — explicit narrow exception to P-007. If the existing AGENTS.md mentions `git subtree`, `git subtree pull`, `git subtree push`, `subtree add`, `.gitmodules`, or `git submodule` in the Active Context / Structure / Project-specific rules sections, propose a rewrite to the canonical clone+gitignore form. Canonical Active Context bullet template (substitute the repo name for `make-ai-agents`): `\`make-ai-agents\` is a **local clone, gitignored** at \`make-ai-agents/\` (not a subtree, not a submodule — see \`.gitignore\`). Refresh with \`cd make-ai-agents && git pull\`. Re-clone fresh by removing the folder and running \`git clone https://github.com/chaz-clark/Make-AI-Agents.git make-ai-agents\` from the repo root.` Surface each rewrite in the refresh handoff doc so the maintainer sees the change explicitly.
 - Together: lean AGENTS.md prose + co-located discipline files + current vendoring-pattern language = discipline propagates correctly without duplication-drift, broken-reference, or stale-instruction-drift.
 
-### 2. Stale Active Context
+### 2. Stale Active Context (or Bloated Active Context)
 
-**Problem**: Six months after generation, the Active Context section still says "v3.0 just shipped" and lists issues that were closed long ago.
+**Problem**: Six months after generation, the Active Context section still says "v3.0 just shipped" and lists issues that were closed long ago. **OR** — the Active Context has grown into an append-only release log spanning hundreds of lines, where every shipped feature since the project's inception is preserved chronologically. The first failure is staleness; the second is bloat.
 
-**Why it happens**: Active Context isn't owned by the make_AGENTS skill after generation — it's the developer's responsibility to update.
+**Why it happens**: Active Context isn't owned by the make_AGENTS skill after generation — it's the developer's responsibility to update. Without discipline, it either goes stale (unmaintained) or bloats (over-maintained as an everything-log). The bloat variant often has a *fresh* date stamp, so date-based freshness checks (AGENTS-QC-008) pass — masking the real problem.
 
-**Solution**: Generate the Active Context section with a date stamp at the top: `_Last updated: YYYY-MM-DD_`. Include a comment in the section explaining when it should be refreshed.
+**Solution**: Generate the Active Context section with a date stamp at the top: `_Last updated: YYYY-MM-DD_`. Include a comment in the section explaining when it should be refreshed. **Enforce boundaries**: AGENTS-QC-011 flags when Active Context exceeds ~5 dated entries or ~150 lines. Recommended remedy: keep the latest 2-3 releases + in-flight work + open follow-ups; move the historical release log to `CHANGELOG.md` (per Principle #2 — long-form documentation lives in READMEs/CHANGELOG, not AGENTS.md).
 
 ### 3. Tool-Specific Instructions
 

--- a/make_AGENTS_qc.json
+++ b/make_AGENTS_qc.json
@@ -165,6 +165,24 @@
           "priority": "medium",
           "weight": 0.07,
           "dimension": "specificity"
+        },
+        {
+          "rule_id": 10,
+          "name": "Total File Size Within Threshold",
+          "condition": "AGENTS.md total size stays within readable limits. Soft threshold: ~1200 lines or ~12,000 tokens (warn). Hard threshold: ~25,000 tokens (the common Read-tool cap in Claude Code and similar tools — beyond this the file cannot be read in one pass).",
+          "action": "Medium failure when file exceeds soft threshold (1200 lines / 12k tokens). High failure when file exceeds hard threshold (25k tokens) — file becomes unreadable in one pass. Recommend: trim Active Context to current-state-only (move historical log to CHANGELOG.md), move domain knowledge to knowledge/ files, move long-form docs to README/docs/.",
+          "priority": "medium",
+          "weight": 0.10,
+          "dimension": "completeness"
+        },
+        {
+          "rule_id": 11,
+          "name": "Active Context Is Current-State-Only, Not Append-Only Log",
+          "condition": "Active Context section contains current state, in-flight work, and recent major changes ONLY — not a full historical changelog. Flag when Active Context has >5 dated/versioned release entries OR the section exceeds ~150 lines.",
+          "action": "Medium failure when Active Context looks like an append-only release log (>5 dated entries or >150 lines). Recommend: keep latest 2-3 releases + in-flight work + open follow-ups; move the historical release log to CHANGELOG.md (per Principle #2 — long-form documentation lives in READMEs/CHANGELOG, not AGENTS.md). The overflow does NOT belong in knowledge/ — per make_agent_knowledge Principles #1-#2, knowledge files are runtime artifacts (reference/identity/procedural shapes); a release log is none of those and would fail KNW-QC-003.",
+          "priority": "medium",
+          "weight": 0.08,
+          "dimension": "currency"
         }
       ],
       "evaluation_order": "priority",
@@ -216,10 +234,11 @@
     "dimensions": {
       "completeness": {
         "weight": 0.25,
-        "rules": [1, 7],
+        "rules": [1, 7, 10],
         "checks": [
           "All 5 required sections present and in order",
-          "Structure section accurately reflects the repo (when repo accessible)"
+          "Structure section accurately reflects the repo (when repo accessible)",
+          "Total file size stays within readable thresholds (soft: 1200 lines/12k tokens; hard: 25k tokens)"
         ]
       },
       "specificity": {
@@ -240,10 +259,11 @@
       },
       "currency": {
         "weight": 0.15,
-        "rules": [3, 8],
+        "rules": [3, 8, 11],
         "checks": [
           "Active Context has a date stamp",
-          "Date stamp is within 90 days"
+          "Date stamp is within 90 days",
+          "Active Context is current-state-only, not an append-only log (≤5 dated entries, ≤150 lines)"
         ]
       },
       "tool_agnosticism": {
@@ -290,7 +310,7 @@
         "status": "PASS | NEEDS_IMPROVEMENT | FAIL",
         "agents_md_path": "string",
         "repo_root": "string or null",
-        "rules_evaluated": "integer (1-9)",
+        "rules_evaluated": "integer (1-11)",
         "rules_skipped": "array of rule_ids skipped (e.g. [7] if no repo_root)",
         "timestamp": "ISO 8601"
       },
@@ -309,7 +329,7 @@
         "low": "array of issue objects"
       },
       "issue_object_shape": {
-        "rule_id": "integer (1-9)",
+        "rule_id": "integer (1-11)",
         "rule_name": "string",
         "severity": "critical|high|medium|low",
         "location": "string (line number or section name in AGENTS.md)",
@@ -453,7 +473,7 @@
         "date": "2026-04-29",
         "changes": [
           "Initial QC skill for AGENTS.md.",
-          "9 rules across 6 quality dimensions: completeness, specificity, discipline_integration, currency, tool_agnosticism, optional_section_justification.",
+          "11 rules across 6 quality dimensions: completeness, specificity, discipline_integration, currency, tool_agnosticism, optional_section_justification.",
           "Rule 7 (Structure Genchi Genbutsu) catches drift between AGENTS.md claims and actual repo state when repo_root is provided. Includes an in-flight-content exception for files documented as about-to-commit.",
           "Rule 6 catches the over-paraphrasing-Working-Style failure mode observed during AGENTS.md iteration 1.",
           "Skill itself operates as interaction_pattern: read_only with applicable_principles P-001, P-003, P-007, P-008, P-009, P-010 (skip P-002, P-004, P-005, P-006).",

--- a/make_AGENTS_qc.md
+++ b/make_AGENTS_qc.md
@@ -39,7 +39,7 @@ A fast-path validation flow:
 1. **[Locate]**: Find the target `AGENTS.md` and (optionally) the repo root it describes.
    - Example: `AGENTS.md` at `/path/to/project/AGENTS.md`; repo root is `/path/to/project/`.
 
-2. **[Parse rules]**: Load structured rules from `make_AGENTS_qc.json` — the 9 rules, their weights, and severity levels.
+2. **[Parse rules]**: Load structured rules from `make_AGENTS_qc.json` — the 11 rules, their weights, and severity levels.
 
 3. **[Read sources]**: Read the AGENTS.md fully. If repo root is provided, read the discipline source at `knowledge/behavioral_discipline.md/.json` (or equivalent) and run `git ls-files` for the structure check.
 
@@ -63,7 +63,7 @@ For detailed rules and scoring, see `make_AGENTS_qc.json`.
 - Worked examples of good and broken AGENTS.md files
 
 ### The JSON File (.json) Contains:
-- The 9 numbered rules with conditions, actions, weights, severity
+- The 11 numbered rules with conditions, actions, weights, severity
 - Quality dimension definitions with weights
 - Severity levels (critical / high / medium / low)
 - Test cases and expected outputs
@@ -140,7 +140,7 @@ P-002, P-004, P-005, P-006 are skipped per `read_only.skip_unless_applicable` �
 
 Conversational invocation — this is a meta-skill, not a script. Example prompt to your agentic dev tool:
 
-> "Use `make_AGENTS_qc.md` and `make_AGENTS_qc.json` to validate `<path>/AGENTS.md` against the make_AGENTS contract. The repo root is `<path>/`. Apply all 9 rules. Output a scored report with critical issues first."
+> "Use `make_AGENTS_qc.md` and `make_AGENTS_qc.json` to validate `<path>/AGENTS.md` against the make_AGENTS contract. The repo root is `<path>/`. Apply all 11 rules. Output a scored report with critical issues first."
 
 The skill responds with a structured report (see `make_AGENTS_qc.json` → `output_format`).
 
@@ -254,7 +254,7 @@ Recommendations:
 
 **Scenario**: Validating an AGENTS.md from a different team's project where you only have the file, not the repo.
 
-**Approach**: Skill applies Rules 1, 2, 3, 4, 5, 6, 8, 9 (the rules that don't require repo access). Skips Rule 7 (Structure Accuracy) and any deep verification. Notes the limitation in the report header.
+**Approach**: Skill applies Rules 1, 2, 3, 4, 5, 6, 8, 9, 10, 11 (the rules that don't require repo access). Skips Rule 7 (Structure Accuracy) and any deep verification. Notes the limitation in the report header.
 
 ---
 
@@ -275,7 +275,9 @@ For full structured tests, see `make_AGENTS_qc.json` → `validation.test_cases`
 - Discipline pointer is a pointer, not a duplicate (Rule 6)
 - Structure section matches `git ls-files` output (Rule 7, requires repo access)
 - Active Context date stamp ≤ 90 days old (Rule 8)
-- Migration Notes references match Migration Notes content (Rule 9)
+- No template placeholders in body (Rule 9)
+- Total file size within thresholds (Rule 10)
+- Active Context is current-state-only, not append-only log (Rule 11)
 
 ### Quality Dimensions (6)
 


### PR DESCRIPTION
Closes #17

## Summary

Adds two new QC rules to **enforce Principle #2 (Concise)** in :

### AGENTS-QC-010: Total File Size Threshold
- **Soft threshold**: ~1200 lines / ~12k tokens (medium failure - warn)
- **Hard threshold**: ~25k tokens (high failure - exceeds Read-tool cap)
- **Maps to**: completeness dimension (weight 0.10)
- **Remediation**: trim Active Context, move knowledge to knowledge/ files, move docs to README

### AGENTS-QC-011: Active Context Current-State-Only
- **Triggers**: >5 dated entries OR >150 lines
- **Maps to**: currency dimension (weight 0.08)
- **Remediation**: keep latest 2-3 releases + in-flight work; move historical log to CHANGELOG.md

## Changes

- ✅ Added rules 10 and 11 to `make_AGENTS_qc.json`
- ✅ Updated dimension mappings (completeness + currency)
- ✅ Updated all "9 rules" → "11 rules" cross-references
- ✅ Updated `make_AGENTS.md` Principle #2 to reference the new checks
- ✅ Expanded Common Pitfall #2 to cover both staleness and bloat

## Empirical Grounding

Per the issue: `canvas-toolbox/AGENTS.md` reached **180KB / 53,810 tokens** and exceeded Claude Code's 25k Read-tool limit, making the project context file unreadable in one pass. These checks prevent that failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)